### PR TITLE
refactor: use modern str functions

### DIFF
--- a/generator/lib/builder/om/OMBuilder.php
+++ b/generator/lib/builder/om/OMBuilder.php
@@ -177,11 +177,11 @@ abstract class OMBuilder extends DataModelBuilder
     {
         $pkg = $this->getPackage();
 
-        if (false !== strpos($pkg, '/')) {
+        if (str_contains($pkg, '/')) {
             return preg_replace('#\.(map|om)$#', '/\1', $pkg);
         }
 
-        if ('.' === substr($pkg, 0, 1)) {
+        if (str_starts_with($pkg, '.')) {
             $pkg = substr($pkg, 1);
         }
 
@@ -551,7 +551,7 @@ abstract class OMBuilder extends DataModelBuilder
             $modifier = $behavior->$modifierGetter();
 
             if (method_exists($modifier, $hookName)) {
-                if (strpos($hookName, 'Filter') !== false) {
+                if (str_contains($hookName, 'Filter')) {
                     // filter hook: the script string will be modified by the behavior
                     $modifier->$hookName($script, $this);
                 } else {
@@ -617,7 +617,7 @@ abstract class OMBuilder extends DataModelBuilder
         }
 
         // end of line
-        if (strlen($content) && "\n" != substr($content, -1)) {
+        if (strlen($content) && !str_ends_with($content, "\n")) {
             $content = $content . "\n";
         }
 

--- a/generator/lib/builder/om/PHP5NodeBuilder.php
+++ b/generator/lib/builder/om/PHP5NodeBuilder.php
@@ -733,7 +733,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
         if (\$this->obj->isDeleted())
             throw new PropelException('Cannot save deleted node.');
 
-        if (substr(\$this->getNodePath(), 0, 1) == '0')
+        if (str_starts_with(\$this->getNodePath(), '0'))
             throw new PropelException('Cannot save unattached node.');
 
         if (\$this->obj->isColumnModified($nodePeerClassname::NPATH_COLNAME))

--- a/generator/lib/builder/om/PHP5NodePeerBuilder.php
+++ b/generator/lib/builder/om/PHP5NodePeerBuilder.php
@@ -410,8 +410,9 @@ abstract class " . $this->getClassname() . " {
      */
     public static function moveNodeSubTree(\$srcPath, \$dstPath, PropelPDO \$con = null)
     {
-        if (substr(\$dstPath, 0, strlen(\$srcPath)) == \$srcPath)
+        if (str_starts_with(\$dstPath, \$srcPath)) {
             throw new PropelException('Cannot move a node subtree within itself.');
+        }
 
         if (\$con === null)
             \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);

--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -203,7 +203,7 @@ class PHP5ObjectBuilder extends ObjectBuilder
         if (null === $parentClass) {
             $parentClass = ClassTools::classname($this->getBaseClass());
 
-            if (false === strpos($this->getBaseClass(), '.')) {
+            if (!str_contains($this->getBaseClass(), '.')) {
                 $this->declareClass($this->getBaseClass());
             } else {
                 $this->declareClass($parentClass);

--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -1019,7 +1019,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $script .= "
         }
 
-        if (strpos(\$format, '%') !== false) {
+        if (str_contains(\$format, '%')) {
             @trigger_error(\"Use of strftime format is deprecated in method: \".__CLASS__.'::'.__METHOD__, \\E_USER_DEPRECATED);
             return strftime(\$format, \$dt->format('U'));
         }

--- a/generator/lib/config/GeneratorConfig.php
+++ b/generator/lib/config/GeneratorConfig.php
@@ -67,7 +67,7 @@ class GeneratorConfig implements GeneratorConfigInterface
 
         $renamedPropelProps = array();
         foreach ($props as $key => $propValue) {
-            if (strpos($key, "propel.") === 0) {
+            if (str_starts_with($key, "propel.")) {
                 $newKey = substr($key, strlen("propel."));
                 $j = strpos($newKey, '.');
                 while ($j !== false) {

--- a/generator/lib/config/QuickGeneratorConfig.php
+++ b/generator/lib/config/QuickGeneratorConfig.php
@@ -123,7 +123,7 @@ class QuickGeneratorConfig implements GeneratorConfigInterface
 
         $renamedPropelProps = array();
         foreach ($props as $key => $propValue) {
-            if (strpos($key, "propel.") === 0) {
+            if (str_starts_with($key, "propel.")) {
                 $newKey = substr($key, strlen("propel."));
                 $j = strpos($newKey, '.');
                 while ($j !== false) {

--- a/generator/lib/model/Column.php
+++ b/generator/lib/model/Column.php
@@ -1285,17 +1285,17 @@ class Column extends XMLElement
             $this->size = $size;
         }
 
-        if (strpos($tn, "CHAR") !== false) {
+        if (str_contains($tn, "CHAR")) {
             $this->domain->setType(PropelTypes::VARCHAR);
-        } elseif (strpos($tn, "INT") !== false) {
+        } elseif (str_contains($tn, "INT")) {
             $this->domain->setType(PropelTypes::INTEGER);
-        } elseif (strpos($tn, "FLOAT") !== false) {
+        } elseif (str_contains($tn, "FLOAT")) {
             $this->domain->setType(PropelTypes::FLOAT);
-        } elseif (strpos($tn, "DATE") !== false) {
+        } elseif (str_contains($tn, "DATE")) {
             $this->domain->setType(PropelTypes::DATE);
-        } elseif (strpos($tn, "TIME") !== false) {
+        } elseif (str_contains($tn, "TIME")) {
             $this->domain->setType(PropelTypes::TIMESTAMP);
-        } elseif (strpos($tn, "BINARY") !== false) {
+        } elseif (str_contains($tn, "BINARY")) {
             $this->domain->setType(PropelTypes::LONGVARBINARY);
         } else {
             $this->domain->setType(PropelTypes::VARCHAR);

--- a/generator/lib/model/Database.php
+++ b/generator/lib/model/Database.php
@@ -431,7 +431,7 @@ class Database extends ScopedElement
             $this->tablesByName[$tbl->getName()] = $tbl;
             $this->tablesByLowercaseName[strtolower($tbl->getName())] = $tbl;
             $this->tablesByPhpName[$tbl->getPhpName()] = $tbl;
-            if (strpos($tbl->getNamespace(), '\\') === 0) {
+            if (str_starts_with($tbl->getNamespace(), '\\')) {
                 $tbl->setNamespace(substr($tbl->getNamespace(), 1));
             } elseif ($namespace = $this->getNamespace()) {
                 if ($tbl->getNamespace() === null) {

--- a/generator/lib/model/PhpNameGenerator.php
+++ b/generator/lib/model/PhpNameGenerator.php
@@ -52,7 +52,7 @@ class PhpNameGenerator implements NameGenerator
 
         if (count($inputs) > 2) {
             $prefix = $inputs[2];
-            if ($prefix != '' && substr($schemaName, 0, strlen($prefix)) == $prefix) {
+            if ($prefix != '' && str_starts_with($schemaName, $prefix)) {
                 $schemaName = substr($schemaName, strlen($prefix));
             }
         }

--- a/generator/lib/reverse/mysql/MysqlSchemaParser.php
+++ b/generator/lib/reverse/mysql/MysqlSchemaParser.php
@@ -173,7 +173,7 @@ class MysqlSchemaParser extends BaseSchemaParser
     {
         $name = $row['Field'];
         $is_nullable = ($row['Null'] == 'YES');
-        $autoincrement = (strpos($row['Extra'], 'auto_increment') !== false);
+        $autoincrement = (str_contains($row['Extra'], 'auto_increment'));
         $size = null;
         $precision = null;
         $scale = null;

--- a/generator/lib/reverse/oracle/OracleSchemaParser.php
+++ b/generator/lib/reverse/oracle/OracleSchemaParser.php
@@ -85,7 +85,7 @@ class OracleSchemaParser extends BaseSchemaParser
         }
         // First load the tables (important that this happen before filling out details of tables)
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            if (strpos($row['OBJECT_NAME'], '$') !== false) {
+            if (str_contains($row['OBJECT_NAME'], '$')) {
                 // this is an Oracle internal table or materialized view - prune
                 continue;
             }
@@ -146,7 +146,7 @@ class OracleSchemaParser extends BaseSchemaParser
         $stmt = $this->dbh->query("SELECT COLUMN_NAME, DATA_TYPE, NULLABLE, DATA_LENGTH, DATA_PRECISION, DATA_SCALE, DATA_DEFAULT FROM USER_TAB_COLS WHERE TABLE_NAME = '" . $table->getName() . "'");
         /* @var stmt PDOStatement */
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            if (strpos($row['COLUMN_NAME'], '$') !== false) {
+            if (str_contains($row['COLUMN_NAME'], '$')) {
                 // this is an Oracle internal column - prune
                 continue;
             }
@@ -164,7 +164,7 @@ class OracleSchemaParser extends BaseSchemaParser
             if ($type == "FLOAT" && $row["DATA_PRECISION"] == 126) {
                 $type = "DOUBLE";
             }
-            if (strpos($type, 'TIMESTAMP(') !== false) {
+            if (str_contains($type, 'TIMESTAMP(')) {
                 $type = substr($type, 0, strpos($type, '('));
                 $default = "0000-00-00 00:00:00";
                 $size = null;

--- a/generator/lib/task/PropelSQLExec.php
+++ b/generator/lib/task/PropelSQLExec.php
@@ -264,7 +264,7 @@ class PropelSQLExec extends AbstractPropelTask
 
             // We want to make sure that the base schemas
             // are inserted first.
-            if (strpos($sqlfile, "schema.sql") !== false) {
+            if (str_contains($sqlfile, "schema.sql")) {
                 // add to the beginning of the array
                 array_unshift($databases[$database], $sqlfile);
             } else {

--- a/generator/lib/util/PropelPHPParser.php
+++ b/generator/lib/util/PropelPHPParser.php
@@ -108,7 +108,7 @@ class PropelPHPParser
                     // Decrease the bracket-counter (not the class-brackets: `$isInFunction` must be true!)
                     $functionBracketBalance--;
                     if ($functionBracketBalance == 0) {
-                        if (strpos($methodCode, 'function ' . $methodName . '(') !== false) {
+                        if (str_contains($methodCode, 'function ' . $methodName . '(')) {
                             return $methodCode;
                         } else {
                             // If it's the closing bracket of the function, reset `$isInFunction`

--- a/generator/lib/util/PropelQuickBuilder.php
+++ b/generator/lib/util/PropelQuickBuilder.php
@@ -127,7 +127,7 @@ class PropelQuickBuilder
     {
         $statements = PropelSQLParser::parseString($this->getSQL());
         foreach ($statements as $statement) {
-            if (strpos($statement, 'DROP') === 0) {
+            if (str_starts_with($statement, 'DROP')) {
                 // drop statements cause errors since the table doesn't exist
                 continue;
             }

--- a/generator/lib/util/PropelSQLParser.php
+++ b/generator/lib/util/PropelSQLParser.php
@@ -233,7 +233,7 @@ class PropelSQLParser
             }
 
             if (!$isInString) {
-                if (false !== strpos($lowercaseString, 'delimiter ')) {
+                if (str_contains($lowercaseString, 'delimiter ')) {
                     // remove DELIMITER from string because it's a command-line keyword only
                     $parsedString = trim(str_ireplace('delimiter ', '', $parsedString));
 

--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -721,7 +721,7 @@ class Propel
     private static function processDriverOptions($source, &$write_to)
     {
         foreach ($source as $option => $optiondata) {
-            if (is_string($option) && strpos($option, '::') !== false) {
+            if (is_string($option) && str_contains($option, '::')) {
                 $key = $option;
             } elseif (is_string($option)) {
                 $key = 'PropelPDO::' . $option;
@@ -732,7 +732,7 @@ class Propel
             $key = constant($key);
 
             $value = $optiondata['value'];
-            if (is_string($value) && strpos($value, '::') !== false) {
+            if (is_string($value) && str_contains($value, '::')) {
                 if (!defined($value)) {
                     throw new PropelException("Invalid PDO option/attribute value specified: " . $value);
                 }

--- a/runtime/lib/adapter/DBMySQL.php
+++ b/runtime/lib/adapter/DBMySQL.php
@@ -252,7 +252,7 @@ EXCEPTION
                 );
                 }
             } else {
-                if (strpos($params['dsn'], ';charset=') === false) {
+                if (!str_contains($params['dsn'], ';charset=')) {
                     $params['dsn'] .= ';charset=' . $params['settings']['charset']['value'];
                     unset($params['settings']['charset']);
                 }

--- a/runtime/lib/map/TableMap.php
+++ b/runtime/lib/map/TableMap.php
@@ -785,7 +785,7 @@ class TableMap
      */
     protected function hasPrefix($data)
     {
-        return (strpos($data, $this->prefix) === 0);
+        return (str_starts_with($data, $this->prefix));
     }
 
     /**

--- a/runtime/lib/parser/PropelCSVParser.php
+++ b/runtime/lib/parser/PropelCSVParser.php
@@ -143,7 +143,7 @@ class PropelCSVParser extends PropelParser
         $special_chars[] = $this->quotechar;
         $special_chars[] = $this->delimiter;
         foreach ($special_chars as $char) {
-            if (strpos($input, $char) !== false) {
+            if (str_contains($input, $char)) {
                 return true;
             }
         }

--- a/runtime/lib/parser/yaml/sfYaml.php
+++ b/runtime/lib/parser/yaml/sfYaml.php
@@ -67,7 +67,7 @@ class sfYaml
     $file = '';
 
     // if input is a file, process it
-    if (strpos($input, "\n") === false && is_file($input)) {
+    if (!str_contains($input, "\n") && is_file($input)) {
       $file = $input;
 
       ob_start();

--- a/runtime/lib/parser/yaml/sfYamlInline.php
+++ b/runtime/lib/parser/yaml/sfYamlInline.php
@@ -93,7 +93,7 @@ class sfYamlInline
         return is_string($value) ? "'$value'" : (int) $value;
       case is_numeric($value):
         return is_infinite($value) ? str_ireplace('INF', '.Inf', strval($value)) : (is_string($value) ? "'$value'" : $value);
-      case false !== strpos($value, "\n") || false !== strpos($value, "\r"):
+      case str_contains($value, "\n") || str_contains($value, "\r"):
         return sprintf('"%s"', str_replace(array('"', "\n", "\r"), array('\\"', '\n', '\r'), $value));
       case preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ - ? | < > = ! % @ ` ]/x', $value):
         return sprintf("'%s'", str_replace('\'', '\'\'', $value));
@@ -247,7 +247,7 @@ class sfYamlInline
           $isQuoted = in_array($sequence[$i], array('"', "'"));
           $value = self::parseScalar($sequence, array(',', ']'), array('"', "'"), $i);
 
-          if (!$isQuoted && false !== strpos($value, ': ')) {
+          if (!$isQuoted && str_contains($value, ': ')) {
             // embedded mapping?
             try {
               $value = self::parseMapping('{'.$value.'}');
@@ -353,11 +353,11 @@ class sfYamlInline
       case '' == $scalar:
       case '~' == $scalar:
         return null;
-      case 0 === strpos($scalar, '!str'):
+      case str_starts_with($scalar, '!str'):
         return (string) substr($scalar, 5);
-      case 0 === strpos($scalar, '! '):
+      case str_starts_with($scalar, '! '):
         return intval(self::parseScalar(substr($scalar, 2)));
-      case 0 === strpos($scalar, '!!php/object:'):
+      case str_starts_with($scalar, '!!php/object:'):
         return unserialize(substr($scalar, 13));
       case ctype_digit($scalar):
         $raw = $scalar;

--- a/runtime/lib/parser/yaml/sfYamlParser.php
+++ b/runtime/lib/parser/yaml/sfYamlParser.php
@@ -79,7 +79,7 @@ class sfYamlParser
         }
 
         // array
-        if (!isset($values['value']) || '' == trim($values['value'], ' ') || 0 === strpos(ltrim($values['value'], ' '), '#')) {
+        if (!isset($values['value']) || '' == trim($values['value'], ' ') || str_starts_with(ltrim($values['value'], ' '), '#')) {
           $c = $this->getRealCurrentLineNb() + 1;
           $parser = new sfYamlParser($c);
           $parser->refs =& $this->refs;
@@ -95,7 +95,7 @@ class sfYamlParser
         $key = sfYamlInline::parseScalar($values['key']);
 
         if ('<<' === $key) {
-          if (isset($values['value']) && '*' === substr($values['value'], 0, 1)) {
+          if (isset($values['value']) && str_starts_with($values['value'], '*')) {
             $isInPlace = substr($values['value'], 1);
             if (!array_key_exists($isInPlace, $this->refs)) {
               throw new InvalidArgumentException(sprintf('Reference "%s" does not exist at line %s (%s).', $isInPlace, $this->getRealCurrentLineNb() + 1, $this->currentLine));
@@ -139,7 +139,7 @@ class sfYamlParser
           $data = $isProcessed;
         }
         // hash
-        else if (!isset($values['value']) || '' == trim($values['value'], ' ') || 0 === strpos(ltrim($values['value'], ' '), '#')) {
+        else if (!isset($values['value']) || '' == trim($values['value'], ' ') || str_starts_with(ltrim($values['value'], ' '), '#')) {
           // if next line is less indented or equal, then it means that the current value is null
           if ($this->isNextLineIndented()) {
             $data[$key] = null;
@@ -162,7 +162,7 @@ class sfYamlParser
           $value = sfYamlInline::load($this->lines[0]);
           if (is_array($value)) {
             $first = reset($value);
-            if ('*' === substr($first, 0, 1)) {
+            if (str_starts_with($first, '*')) {
               $data = array();
               foreach ($value as $alias) {
                 $data[] = $this->refs[substr($alias, 1)];
@@ -309,7 +309,7 @@ class sfYamlParser
    */
   protected function parseValue($value)
   {
-    if ('*' === substr($value, 0, 1)) {
+    if (str_starts_with($value, '*')) {
       if (false !== $pos = strpos($value, '#')) {
         $value = substr($value, 1, $pos - 2);
       } else {

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -659,7 +659,7 @@ class ModelCriteria extends Criteria
     {
         // relation looks like '$leftName.$relationName $relationAlias'
         list($fullName, $relationAlias) = self::getClassAndAlias($relation);
-        if (strpos($fullName, '.') === false) {
+        if (!str_contains($fullName, '.')) {
             // simple relation name, refers to the current table
             $leftName = $this->getModelAliasOrName();
             $relationName = $fullName;
@@ -1129,7 +1129,7 @@ class ModelCriteria extends Criteria
      */
     public static function getClassAndAlias($class)
     {
-        if (strpos($class, ' ') !== false) {
+        if (str_contains($class, ' ')) {
             list($class, $alias) = explode(' ', $class);
         } else {
             $alias = null;
@@ -1152,7 +1152,7 @@ class ModelCriteria extends Criteria
         list($fullName, $relationAlias) = self::getClassAndAlias($relation);
         if ($relationAlias) {
             $relationName = $relationAlias;
-        } elseif (false === strpos($fullName, '.')) {
+        } elseif (!str_contains($fullName, '.')) {
             $relationName = $fullName;
         } else {
             list(, $relationName) = explode('.', $fullName);
@@ -1896,7 +1896,7 @@ class ModelCriteria extends Criteria
             }
         } else {
             // no column match in clause, must be an expression like '1=1'
-            if (strpos($clause, '?') !== false) {
+            if (str_contains($clause, '?')) {
                 if (null === $bindingType) {
                     throw new PropelException("Cannot determine the column to bind to the parameter in clause '$clause'");
                 }
@@ -2045,7 +2045,7 @@ class ModelCriteria extends Criteria
      */
     protected function getColumnFromName($phpName, $failSilently = true)
     {
-        if (strpos($phpName, '.') === false) {
+        if (!str_contains($phpName, '.')) {
             $prefix = $this->getModelAliasOrName();
         } else {
             // $prefix could be either class name or table name
@@ -2237,9 +2237,9 @@ class ModelCriteria extends Criteria
         // Maybe it's a magic call to one of the methods supporting it, e.g. 'findByTitle'
         static $methods = array('findBy', 'findOneBy', 'filterBy', 'orderBy', 'groupBy');
         foreach ($methods as $method) {
-            if (strpos($name, $method) === 0) {
+            if (str_starts_with($name, $method)) {
                 $columns = substr($name, strlen($method));
-                if (in_array($method, array('findBy', 'findOneBy')) && strpos($columns, 'And') !== false) {
+                if (in_array($method, array('findBy', 'findOneBy')) && str_contains($columns, 'And')) {
                     $method = $method . 'Array';
                     $columns = explode('And', $columns);
                     $conditions = array();

--- a/runtime/lib/util/BasePeer.php
+++ b/runtime/lib/util/BasePeer.php
@@ -749,7 +749,7 @@ class BasePeer
 
                 // Add function expression as-is.
 
-                if (strpos($orderByColumn, '(') !== false) {
+                if (str_contains($orderByColumn, '(')) {
                     $orderByClause[] = $orderByColumn;
                     continue;
                 }
@@ -804,7 +804,7 @@ class BasePeer
         // tables should not exist as alias of subQuery
         if ($criteria->hasSelectQueries()) {
             foreach ($fromClause as $key => $ftable) {
-                if (strpos($ftable, ' ') !== false) {
+                if (str_contains($ftable, ' ')) {
                     list($realtable, $tableName) = explode(' ', $ftable);
                 } else {
                     $tableName = $ftable;

--- a/runtime/lib/util/PropelAutoloader.php
+++ b/runtime/lib/util/PropelAutoloader.php
@@ -111,7 +111,7 @@ class PropelAutoloader
             return true;
         }
         // fallback for classes defined with leading backslash
-        if (strpos($class, '\\') === 0) {
+        if (str_starts_with($class, '\\')) {
             $class = substr($class, 1);
 
             return $this->autoload($class);

--- a/test/tools/helpers/PlatformDatabaseBuildTimeBase.php
+++ b/test/tools/helpers/PlatformDatabaseBuildTimeBase.php
@@ -73,7 +73,7 @@ class PlatformDatabaseBuildTimeBase extends \PHPUnit\Framework\TestCase
 
         $statements = PropelSQLParser::parseString($sql);
         foreach ($statements as $statement) {
-            if (strpos($statement, 'DROP') === 0) {
+            if (str_starts_with($statement, 'DROP')) {
                 // drop statements cause errors since the table doesn't exist
                 continue;
             }


### PR DESCRIPTION
`str_contains, str_starts_with, str_ends_with`

```php
<?php

use Rector\Config\RectorConfig;
use Rector\Transform\Rector\ClassMethod\ReturnTypeWillChangeRector;

return function (RectorConfig $rectorConfig) {
    $rectorConfig->paths([
        __DIR__.'/test',
        __DIR__.'/generator/lib',
        __DIR__.'/runtime/lib',
    ]);
    $rectorConfig->skip([
        __DIR__.'/test/**/build/*'
    ]);
    $rectorConfig->rule(\Rector\Php80\Rector\Identical\StrStartsWithRector::class);
    $rectorConfig->rule(\Rector\Php80\Rector\Identical\StrEndsWithRector::class);
    $rectorConfig->rule(\Rector\Php80\Rector\NotIdentical\StrContainsRector::class);
};
```